### PR TITLE
Add UK keyboard layout option + option sublabel clean-up

### DIFF
--- a/core_options.h
+++ b/core_options.h
@@ -127,6 +127,7 @@ static retro_core_option_definition option_defs[] =
 		"Select the keyboard layout (will not change the On Screen Keyboard).",
 		{
 			{ "us",    "US (default)" },
+			{ "uk",    "UK" },
 			{ "br",    "Brazil" },
 			{ "hr",    "Croatia" },
 			{ "cz243", "Czech Republic" },
@@ -151,7 +152,7 @@ static retro_core_option_definition option_defs[] =
 			{ "sf",    "Switzerland (French)" },
 			{ "tr",    "Turkey" },
 		},
-		"auto"
+		"us"
 	},
 	{
 		"dosbox_pure_joystick_timed",


### PR DESCRIPTION
This PR adds a `UK` keyboard layout option, and explicitly sets the default layout to `us` (the current default of `auto` is ignored, since it does not match any of the core option values).

In addition, this PR removes the extra newline characters (`"\n\n"`) that are inserted at the end of some core option sublabels. I realise that these are intended to separate option categories, but extra newlines kinda break the menu layout on everything apart from Ozone...