### PR TITLE
Add gcw0 platform.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ ifeq ($(platform), gcw0)
   # -DDINGUX=1 -MMD
   # -Wall -Wno-unused-variable
   # -D_GNU_SOURCE
-  # -ffunction-sections -D__STDC_CONSTANT_MACROS -fvisibility=hidden 
+  # -D__STDC_CONSTANT_MACROS
   # -D__LIBRETRO__
   
 else ifneq ($(and $(filter ARMv7,$(PROCCPU)),$(filter neon,$(PROCCPU))),)

--- a/include/config.h
+++ b/include/config.h
@@ -108,7 +108,8 @@
 #define C_DYNAMIC_X86 1
 #define C_TARGETCPU X86
 #elif defined(__mips__) && defined(__MIPSEL__)
-#define C_DYNREC 0
+#define C_DYNREC 1
+#define C_UNALIGNED_MEMORY 1
 #define C_TARGETCPU MIPSEL
 #endif
 

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -51,6 +51,7 @@ typedef Bit8u HostReg;
 #define HOST_v1 3
 #define HOST_a0 4
 #define HOST_a1 5
+#define HOST_a2 6
 #define HOST_t4 12
 #define HOST_t5 13
 #define HOST_t6 14
@@ -74,7 +75,7 @@ typedef Bit8u HostReg;
 #define FC_OP2 HOST_a1
 
 // special register that holds the third parameter for _R3 calls (byte accessible)
-#define FC_OP3 HOST_???
+#define FC_OP3 HOST_a2
 
 // register that holds byte-accessible temporary values
 #define FC_TMP_BA1 HOST_t5
@@ -165,7 +166,7 @@ static void gen_mov_word_to_reg(HostReg dest_reg,void* data,bool dword) {
 			cache_addw(0x9000+(temp1<<5)+dest_reg);
 			cache_addw(lohalf+1);		// lbu temp2, 1(temp1)
 			cache_addw(0x9000+(temp1<<5)+temp2);
-#if (_MIPS_ISA==MIPS32R2) || defined(PSP)
+#if (_MIPS_ARCH_MIPS32R2) || defined(PSP)
 			cache_addw(0x7a04);		// ins dest_reg, temp2, 8, 8
 			cache_addw(0x7c00+(temp2<<5)+dest_reg);
 #else
@@ -264,7 +265,7 @@ static void gen_mov_byte_from_reg_low(HostReg src_reg,void* dest) {
 // the register is zero-extended (sign==false) or sign-extended (sign==true)
 static void gen_extend_byte(bool sign,HostReg reg) {
 	if (sign) {
-#if (_MIPS_ISA==MIPS32R2) || defined(PSP)
+#if (_MIPS_ARCH_MIPS32R2) || defined(PSP)
 		cache_addw((reg<<11)+0x420);	// seb reg, reg
 		cache_addw(0x7c00+reg);
 #else
@@ -280,7 +281,7 @@ static void gen_extend_byte(bool sign,HostReg reg) {
 // the register is zero-extended (sign==false) or sign-extended (sign==true)
 static void gen_extend_word(bool sign,HostReg reg) {
 	if (sign) {
-#if (_MIPS_ISA==MIPS32R2) || defined(PSP)
+#if (_MIPS_ARCH_MIPS32R2) || defined(PSP)
 		cache_addw((reg<<11)+0x620);	// seh reg, reg
 		cache_addw(0x7c00+reg);
 #else
@@ -404,7 +405,7 @@ static Bit32u INLINE gen_call_function_setup(void * func,Bitu paramcount,bool fa
 	return proc_addr;
 }
 
-#ifdef __mips_eabi
+#ifdef _MIPS_ARCH_MIPS32R2
 // max of 8 parameters in $a0-$a3 and $t0-$t3
 
 // load an immediate value as param'th function parameter
@@ -630,7 +631,7 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_SARd:
 			*(Bit32u*)pos=0x00a41007;					// srav $v0, $a0, $a1
 			break;
-#if (_MIPS_ISA==MIPS32R2) || defined(PSP)
+#if (_MIPS_ARCH_MIPS32R2) || defined(PSP)
 		case t_RORd:
 			*(Bit32u*)pos=0x00a41046;					// rotr $v0, $a0, $a1
 			break;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <sstream>
 #include <stddef.h>
+#include <stdlib.h>
 #include "dosbox.h"
 #include "cpu.h"
 #include "memory.h"

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -534,7 +534,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 	}
 	df->Close();
 	delete df;
-	istringstream inString; //  = istringstream(dosfilebuf);
+	istringstream inString(dosfilebuf);
 	istream& in = (istream&)inString;
 #else
 	char tmp[MAX_FILENAME_LENGTH];	// dirname can change its argument

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -534,7 +534,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 	}
 	df->Close();
 	delete df;
-	istringstream inString = istringstream(dosfilebuf);
+	istringstream inString; //  = istringstream(dosfilebuf);
 	istream& in = (istream&)inString;
 #else
 	char tmp[MAX_FILENAME_LENGTH];	// dirname can change its argument

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -21,6 +21,8 @@
 #ifndef _DRIVES_H__
 #define _DRIVES_H__
 
+#include <stdlib.h>
+
 #include <vector>
 #include <string>
 #include <sys/types.h>

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -22,6 +22,7 @@
 	That should call the mixer start from there or something.
 */
 
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <math.h>


### PR DESCRIPTION
Changes to get dosbox-pure to compile with the rg350/opendingux toolchain. Resolves https://github.com/schellingb/dosbox-pure/issues/79

You have to put the toolchain at `/opt/gcw0-toolchain/` and then you can cross-compile by running `make platform=gcw0 -j8`.

Install by copying `dosbox_pure_libretro.so` to `~/.retroarch/cores/` (SSH or eject SD card)

Tested with latest RetroArch nightly built by the build bot. 

I *did* enable `DYNAREC`, but I think there might be more work to do here. I noticed the dynarec code on this repo has some differences:  https://github.com/dvk11/dosbox-rg350/blob/master/src/cpu/core_dynrec/risc_mipsel32.h

Performance isn't great. The biggest issue is the sound is VERY crackle-y and distorted. I can try to take a video of performance.

I don't have a keyboard on my test device at this time. Will probably invest in one soon.