### PR TITLE
Allow RO text relocation on Android x86

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -66,6 +66,7 @@ else ifeq ($(TARGET_ARCH_ABI), arm64-v8a)
     WITH_DYNAREC := arm64
 else ifeq ($(TARGET_ARCH_ABI), x86)
     WITH_DYNAREC := x86_new
+    LDFLAGS      += -Wl,-z,notext
 else ifeq ($(TARGET_ARCH_ABI), x86_64)
     WITH_DYNAREC := x86_64
 else ifeq ($(TARGET_ARCH_ABI), mips)


### PR DESCRIPTION
NDK r22 uses LLD to link, which disallows read-only text section
relocations. The x86 dynarec code is not position independent so we need
to explicitly enable text relocation. With r21, this was implicitly
enabled by the linker if needed.