### PR TITLE
Add mips32 / OpenDingux to .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
 
+  # OpenDingux
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-mips32.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -150,4 +154,10 @@ libretro-build-libnx-aarch64:
 libretro-build-vita:
   extends:
     - .libretro-vita-static-retroarch-master
+    - .core-defs
+
+# OpenDingux
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-mips32-make-default
     - .core-defs


### PR DESCRIPTION
This just adds the mips32/OpenDingux platform to .gitlab-ci.yml so that we will get builds for the RG350/gcw0

Not sure how to test this?