### PR TITLE
Modified Makefile so you can build Windows version of the core in MSYS2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ else ifneq ($(ISMAC),)
   OUTNAME := dosbox_pure_libretro.dylib
   CXX     ?= clang++
   LDFLAGS := -Wl,-dead_strip
+else ifeq ($(platform),windows)
+  OUTNAME := dosbox_pure_libretro.dll
+  CXX     ?= g++
+  LDFLAGS := -Wl,--gc-sections -fno-ident
 else ifeq ($(platform),vita)
   OUTNAME := dosbox_pure_libretro_vita.a
   CXX     := arm-vita-eabi-g++

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else ifneq ($(ISMAC),)
   OUTNAME := dosbox_pure_libretro.dylib
   CXX     ?= clang++
   LDFLAGS := -Wl,-dead_strip
-else ifeq ($(platform),windows)
+else ifeq ($(platform),windows) #For MSYS2 only
   OUTNAME := dosbox_pure_libretro.dll
   CXX     ?= g++
   LDFLAGS := -Wl,--gc-sections -fno-ident


### PR DESCRIPTION
After several failed attempts to build the Windows version of the core using Visual Studio 2019, I made a small edit to the Makefile to build the core in MSYS2. To build type make platform=windows.