### PR TITLE
Fixed unexpected crashes caused by audio

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -636,8 +636,8 @@ MIXER_CallBack(void * /*userdata*/, uint8_t *stream, int len) {
 	if( Mixer_irq_important() )
 		mixer.tick_add = calc_tickadd(mixer.freq);
 
-	mixer.done -= reduce;
-	mixer.needed -= reduce;
+	mixer.done = (mixer.done>reduce) ? mixer.done-reduce : 0;
+	mixer.needed = (mixer.needed>reduce) ? mixer.needed-reduce : 0;
 	pos = mixer.pos;
 	mixer.pos = (mixer.pos + reduce) & MIXER_BUFMASK;
 	if(need != reduce) {


### PR DESCRIPTION
Since mixer.done and needed are declared as unsigned containers, they should be checked to avoid overflow. It was causing unexpected crashes.