### PR TITLE
gitignore .dsstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 *.dll
 *.so
 *.dylib
+.DS_Store


### PR DESCRIPTION
For the macos users to avoid git thinking the repo has been touched.