### PR TITLE
[Libnx] Fix Jit buffer handling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,10 +187,10 @@ libretro-build-tvos-arm64:
 #    - .core-defs
 
 ## Nintendo Switch
-#libretro-build-libnx-aarch64:
-#  extends:
-#    - .libretro-libnx-static-retroarch-master
-#    - .core-defs
+libretro-build-libnx-aarch64:
+  extends:
+    - .libretro-libnx-static-retroarch-master
+    - .core-defs
 
 # PlayStation Vita
 libretro-build-vita:

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ else ifeq ($(platform),libnx)
   export DEPSDIR = $(CURDIR)
   include $(DEVKITPRO)/libnx/switch_rules
   COMMONFLAGS += -I$(LIBNX)/include/ -ftls-model=local-exec -specs=$(LIBNX)/switch.specs
-  COMMONFLAGS += $(INCLUDE) -D__SWITCH__ -DHAVE_LIBNX
+  COMMONFLAGS += $(INCLUDE) -D__SWITCH__ -DHAVE_LIBNX -fpic
   STATIC_LINKING = 1
 else ifeq ($(platform),gcw0)
   # You must used the toolchain built on or around 2014-08-20


### PR DESCRIPTION
Someone borked my prior implementation, just move to a little less efficient but stable interface.
Enable CI/CD as well.
There is still a crash on exit (exit itself is fine, next loading application corrupts tho), might be related to block linking in CacheBlockDynRec::Clear but I cant confirm this rn.
Fwiw this has been tested and enabled the dynarec to function again.
-fpic is required for static linkage to not get relocations in readonly segments btw.