### PR TITLE
Some fixes for aspect ratio with padding and double-scan

### DIFF
--- a/core_options.h
+++ b/core_options.h
@@ -528,14 +528,14 @@ static retro_core_option_v2_definition option_defs[] =
 	{
 		"dosbox_pure_aspect_correction",
 		"Aspect Ratio Correction", NULL,
-		"When enabled, the core's aspect ratio is set to what a CRT monitor would display.", NULL,
+		"Adjust the core's aspect ratio to approximate what a CRT monitor would display.", NULL,
 		"Video",
 		{
-			{ "false", "Disabled, use square pixels (Default)" },
-			{ "true",  "Enabled, match ratio to emulated monitor" },
-			{ "scan",  "Enabled, match number of scan lines to emulated monitor (for CRT shaders)" },
-			{ "4by3",  "Enabled, add black borders to pad to 4:3" },
-			{ "both",  "Enabled, both match scan lines and pad to 4:3" },
+			{ "false", "Off (default)" },
+			{ "true", "On (single-scan)" },
+			{ "doublescan", "On (double-scan when applicable)" },
+			{ "padded", "Padded to 4:3 (single-scan)" },
+			{ "padded-doublescan", "Padded to 4:3 (double-scan when applicable)" },
 		},
 		"false"
 	},

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1538,16 +1538,15 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		doubleheight=true;
 	}
 	vga.draw.vblank_skip = vblank_skip;
-		
-	if (!(IS_VGA_ARCH && (svgaCard==SVGA_None) && (vga.mode==M_EGA || vga.mode==M_VGA))) {
-		//Only check for extra double height in vga modes
-		//(line multiplying by address_line_total)
-		if (!doubleheight && (vga.mode<M_TEXT) && !(vga.draw.address_line_total & 1)) {
-			vga.draw.address_line_total/=2;
-			doubleheight=true;
-			height/=2;
-		}
+
+	//Only check for extra double height in vga modes
+	//(line multiplying by address_line_total)
+	if (!doubleheight && (vga.mode<M_TEXT) && !(vga.draw.address_line_total & 1)) {
+		vga.draw.address_line_total/=2;
+		doubleheight=true;
+		height/=2;
 	}
+
 	vga.draw.lines_total=height;
 	vga.draw.parts_lines=vga.draw.lines_total/vga.draw.parts_total;
 	vga.draw.line_length = width * ((bpp + 1) / 8);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1547,6 +1547,12 @@ void VGA_SetupDrawing(Bitu /*val*/) {
 		height/=2;
 	}
 
+	//DBP: Standards prior to VGA (e.g. CGA, EGA) don't do double-scanning
+	if (doubleheight && machine<MCH_VGA) {
+		doubleheight=false;
+		aspect_ratio *= 2.0;
+	}
+
 	vga.draw.lines_total=height;
 	vga.draw.parts_lines=vga.draw.lines_total/vga.draw.parts_total;
 	vga.draw.line_length = width * ((bpp + 1) / 8);


### PR DESCRIPTION
Fixes for most of the issues referenced in https://github.com/schellingb/dosbox-pure/issues/512#issuecomment-2438927259. Also, makes the choices a bit more undestandable to less advanced users.

The overscan area had a different thickness depending on whether or not a double-scanning choice was selected. I also attempted to fix this (the overscan area was already inaccurate to begin with, so this shouldn't make it worse at least).

This uncovered an issue with `vgaonly` emulation, whereas mode 13h was being handled as 320x400 instead of 320x200 with line-doubling. This seems to have been something that was left over after some other underlying issue got fixed. See: https://github.com/jwilk-mirrors/dosbox/commit/74fe003a63d3ebe01d5def9d35c16c1bcc8dd93f

It also uncovered an issue with double-scan being applied for EGA and CGA cards, when these never did double-scanning on real hardware (some particular EGA cards might, see [this thread on Vogons](https://www.vogons.org/viewtopic.php?t=85894), but that isn't expected in this case).