### PR TITLE
Improved Voodoo performance with CPU threaded rendering (#519)

### DIFF
--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -6122,7 +6122,7 @@ static void triangle_worker_run(triangle_worker& tworker)
 	tworker.totalpix = pixsum;
 
 	// Don't wake up threads for just a few pixels
-	if (tworker.totalpix <= 200)
+	if (tworker.totalpix <= 350)
 	{
 		triangle_worker_work(tworker, 0, tworker.triangle_threads + 1);
 		return;


### PR DESCRIPTION
Improves 3dfx Voodoo frame rates by 3 - 8% (sometimes slightly less or more) depending on the game. This applies to the core options 'Software Multi Threaded (default)' and 'Software Multi Threaded, low quality'.

As mentioned in #519 many games were thoroughly tested and the results can be viewed [here.](https://github.com/schellingb/dosbox-pure/issues/519#issuecomment-2438388162)