### PR TITLE
Add default "square" aspect ratio correction (same as "false" in 0.9.9 and DOSBox)

### DIFF
--- a/core_options.h
+++ b/core_options.h
@@ -531,13 +531,14 @@ static retro_core_option_v2_definition option_defs[] =
 		"Adjust the core's aspect ratio to approximate what a CRT monitor would display.", NULL,
 		"Video",
 		{
-			{ "false", "Off (default)" },
+			{ "square", "Square Pixels (default)"},
+			{ "uncorrected", "Uncorrected" },
 			{ "true", "On (single-scan)" },
 			{ "doublescan", "On (double-scan when applicable)" },
 			{ "padded", "Padded to 4:3 (single-scan)" },
 			{ "padded-doublescan", "Padded to 4:3 (double-scan when applicable)" },
 		},
-		"false"
+		"square"
 	},
 	{
 		"dosbox_pure_overscan",


### PR DESCRIPTION
Since commit 98c5345 it's no longer possible to select a fully uncorrected "square logical pixels at all times" aspect ratio. This fixes it by adding a new `square` option with the current `false` behavior, while `false` becomes `uncorrected` (label chosen to match equivalent options in other cores).

Existing configurations will have `false` interpreted as `square` to retain compatibility with 0.9.9 behavior. 

I intended to rename the `true` choice to `singlescan` for consistency, but I don't see how I can do that without making existing configurations wrongly switch to `square`.

This is a followup to https://github.com/schellingb/dosbox-pure/issues/512#issuecomment-2452418088.