### PR TITLE
Fix key next to left-shift not working on ISO keyboards

### DIFF
--- a/dosbox_pure_libretro.cpp
+++ b/dosbox_pure_libretro.cpp
@@ -3321,7 +3321,7 @@ void retro_init(void) //#3
 		{RETROK_KP9, KBD_kp9}, {RETROK_KP0, KBD_kp0}, {RETROK_KP_DIVIDE, KBD_kpdivide},
 		{RETROK_KP_MULTIPLY, KBD_kpmultiply}, {RETROK_KP_MINUS, KBD_kpminus},
 		{RETROK_KP_PLUS, KBD_kpplus}, {RETROK_KP_ENTER, KBD_kpenter}, {RETROK_KP_PERIOD, KBD_kpperiod},
-		{RETROK_BACKQUOTE, KBD_grave}
+		{RETROK_BACKQUOTE, KBD_grave}, {RETROK_OEM_102, KBD_extra_lt_gt}
 	};
 	for (int i = 0; i != (sizeof(keymap)/sizeof(keymap[0])); i++)
 	{


### PR DESCRIPTION
Fixes keyboard issue described in #544.