### PR TITLE
Fix compile error on Linux (missing climits include)

### DIFF
--- a/src/dos/drive_union.cpp
+++ b/src/dos/drive_union.cpp
@@ -23,6 +23,7 @@
 
 #include <time.h>
 #include <vector>
+#include <climits>
 
 #define TRUE_RESET_DOSERR (dos.errorcode = save_errorcode, true)
 


### PR DESCRIPTION
Fixes compilation error introduced with commit 30a6ba0e6c37a4636700ab3af9c30180de02ea5f.

```
Building dosbox_pure_libretro.so with RELEASE configuration (obj files stored in build/release) ...
Compiling src/dos/drive_union.cpp ...
src/dos/drive_union.cpp:144:112: error: ‘INT_MAX’ was not declared in this scope
  144 | enum retro_log_level { RETRO_LOG_DEBUG = 0, RETRO_LOG_INFO, RETRO_LOG_WARN, RETRO_LOG_ERROR, RETRO_LOG_DUMMY = INT_MAX };
      |                                                                                                                ^~~~~~~
src/dos/drive_union.cpp:23:1: note: ‘INT_MAX’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
   22 | #include "pic.h"
  +++ |+#include <climits>
   23 | 
make: *** [Makefile:240: build/release/src~dos~drive_union.cpp.o] Error 1
```