### PR TITLE
Fix crash on shutdown when disney=false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ libs/
 *.so
 *.dylib
 jni/*.bat
+.vscode/pro-deployer.json
+.vscode/settings.json

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -379,7 +379,6 @@ private:
 public:
 	DISNEY(Section* configuration):Module_base(configuration) {
 		Section_prop * section=static_cast<Section_prop *>(configuration);
-		if(!section->Get_bool("disney")) return;
 
 		WriteHandler.Install(DISNEY_BASE,disney_write,IO_MB,3);
 		ReadHandler.Install(DISNEY_BASE,disney_read,IO_MB,3);
@@ -410,6 +409,10 @@ static void DISNEY_ShutDown(Section* /*sec*/){
 }
 
 void DISNEY_Init(Section* sec) {
+	auto* s = static_cast<Section_prop*>(sec);
+    if (!s->Get_bool("disney"))
+        return;                     // ← nothing allocated, nothing to shut down
+		
 	test = new DISNEY(sec);
 	sec->AddDestroyFunction(&DISNEY_ShutDown,true);
 }


### PR DESCRIPTION
Fixes a SEGFAULT when setting `disney=false` in a .conf or .bat during core shutdown. The crash occurred due to partially constructed DISNEY objects being deleted, leading to use-after-free or heap corruption in malloc_consolidate().

Issue reproduced with Death Rally using dosbox.bat with the following configuration:

```
disney=false
rally.exe
```