### PR TITLE
Add a keyboard hotkey and more ways to open the on-screen menus

### DIFF
--- a/core_options.h
+++ b/core_options.h
@@ -65,6 +65,7 @@ namespace DBP_Option
 		menu_time,
 		menu_transparency,
 		// Input
+		map_osd_hotkey,
 		map_osd,
 		mouse_input,
 		mouse_wheel,
@@ -325,11 +326,31 @@ static retro_core_option_v2_definition option_defs[DBP_Option::_OPTIONS_TOTAL] =
 
 	// Input
 	{
-		"dosbox_pure_on_screen_keyboard", // legacy name
-		"Use L3 Button to Show Menu", NULL,
-		"Always bind the L3 controller button to show the menu to swap CDs/Disks and use the On-Screen Keyboard.", NULL,
+		"dosbox_pure_menu_action",
+		"Menu Activation Inputs", NULL,
+		"Choose whether the DOSBox Pure menu can be opened using the L3 button, Ctrl+Home hotkey, both, or neither.", NULL,
 		DBP_OptionCat::Input,
-		{ { "true", "On (Default to Menu)" }, { "keyboard", "On (Default to On-Screen Keyboard)" }, { "false", "Off" } },
+		{
+			{ "true",   "L3 and Ctrl+Home (default)" },
+			{ "L3",     "L3 button only" },
+			{ "hotkey", "Ctrl+Home only" },
+			{ "false",  "Off (disable both inputs)" },
+		},
+		"true"
+	},
+	{
+		"dosbox_pure_on_screen_keyboard", // legacy name
+		"Menu Behavior for L3 Button & Hotkey", NULL,
+		"Select which menu is opened by the L3 controller button and Ctrl+Home keyboard hotkey." "\n"
+		"The default setting reopens the previously viewed menu. You can swap CDs/disks on the Start Menu." "\n"
+		"The On-Screen Keyboard is for controllers and touchscreens. Gamepad Mapper can setup controller mapping.", NULL,
+		DBP_OptionCat::Input,
+		{
+			{ "true",      "Open previous menu (default)" },
+			{ "startmenu", "Always open Start Menu (swap CDs/discs)" },
+			{ "keyboard",  "Always open On-Screen Keyboard" },
+			{ "mapper",    "Always open Gamepad Mapper" },
+		},
 		"true"
 	},
 	{


### PR DESCRIPTION
This will add:

1. A keyboard hotkey that opens the DOSBox Pure on-screen menu.
2. New core option to enable or disable the L3 button and the new hotkey, individually.
3. New settings to directly open any of the menus.

The new option was added here:

`Core Options → Input → Menu Activation Inputs`

Available settings:

- **L3 and Ctrl+Home (default)**
- **L3 button only**
- **Ctrl+Home only**
- **Off (disable both inputs)**
<br/>

Ctrl+Home was used for the hotkey, because:

- Is not used by RetroArch.
- Is not an OS shortcut on Windows 7/8/8.1/10/11, macOS, and popular Linux desktops (GNOME/KDE/Cinnamon/Xfce/MATE).
- Is not used as a shortcut on Win3x/9x (or 2000 and XP for that matter).
- Is not used for any DOS or DOSBox shortcuts.
- Works on all major keyboard layouts: ANSI (US), ISO (UK/EU), JIS (Japan), Korean layouts, etc.
- Works on very compact keyboards/laptops which lack a physical Home key (using the Fn key).
- Does not require annoying/awkward finger gymnastics.
- Can be input with one hand on most keyboards, using the right side Ctrl key + Home.

As far as i can see, it's very safe overall as a hotkey...
<br/>

The standalone DOSBox Pure uses Ctrl+F12 to open the menu, but this wasn't used because:

- RetroArch uses the F-keys. It doesn't bind F12 by default (at least on Windows/Android), but...
- RetroArch users often bind the F-keys, so F12 is more likely to already be bound than Home (i often bind F12 for instance).
- If F12 is bound and Game Focus is off, pressing Ctrl+F12 still triggers the RetroArch F12 bind.
- Some laptops assign system functions to F12 (brightness, volume, airplane mode, etc), where F12 is handled by firmware or software, which may "eat" Ctrl+F12 before it reaches RetroArch.

I've also implemented Ctrl+Home in a way that can avoid unwanted in-game inputs. For example, the Ctrl key will fire the weapons in DOOM, but if you hold down Home first, and then press Ctrl, the menu will open without the weapon firing. So either Ctrl+Home or Home+Ctrl can be used, depending on the game. In standalone DBP, Ctrl followed by F12 will open the menu, but only in this specific order, which triggers in-game input whenever a game uses the Ctrl key (unavoidable weapon firing in DOOM).
<br/>

The existing option in:`Input → Use L3 Button to Show Menu` has been renamed to `Menu Behavior for L3 Button & Hotkey`

Available settings:

- **Open previous menu (default)**
Previously this was named “On (Default to Menu)”. The name was changed to describe what it does. It still functions identical: opens the Start Menu on the first L3/hotkey press, then reopens the previously viewed menu on following presses.

- **Always open Start Menu (swap CDs/Disks)**
New setting. It will _always_ open the Start Menu. Intended for users who have no use for the other menus and just want a quick way change CDs/disks. I also put "(swap CDs/Disks)" in the name, being as some people have trouble finding out how to do this, so i tried to make it even more obvious.

- **Always open On-Screen Keyboard**
Replaces "On (Default to On-Screen Keyboard)". Previously this setting opened the OSK first and then reopened the previously viewed menu, so it already behaved similarly to “Open previous menu (default)”. It's now been changed to _always_ open the OSK. I think most controller/touchscreen users would likely prefer to always open the OSK immediately.

- **Always open Gamepad Mapper**
New setting. Does exactly what it says. Useful for when first configuring the controls of many games/a large game collection, as this can now save a decent amount of time overall. Also good for quickly testing out different controller mappings when experimenting to find the best button layout. Many games do not need disc swapping or the OSK, so this could also be the best setting to use in those cases.
<br/>

So that's everything. What do you think?

I wanted to add a hotkey because sometimes i'm literally too lazy to go get a controller, just to press the L3 button to open the menu, while there's already a keyboard right in front of me. And the DBP menus are a really useful and unique feature, so the more ways to access them, the better. It also felt odd that the standalone version had a keyboard hotkey, but the core didn't. Maybe i'm missing something here? Because i would have expected this core to already have a hotkey, unless there's a reason not to. I'm also learning C++, not familiar with this projects files, this is my first _proper_ PR, and `dosbox_pure_libretro.cpp` is long and complex... Hopefully everything has been done right... Right?? I'm hesitant to submit this 😅

But these changes have been thoroughly tested on Win10/11 with several different keyboards/controllers, and Android was tested with a controller. It works without issues. [Here's](https://github.com/user-attachments/files/24244535/dosbox_pure_libretro.zip) a Windows build to try out.