### PR TITLE
Opcodes fix for bigendian cpu's

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,11 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
 
+  #################################### MISC ##################################
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 ##############################################################################
 #################################### STAGES ##################################
 ##############################################################################
@@ -242,3 +247,10 @@ libretro-build-miyoo-arm32:
 #  extends:
 #    - .libretro-retrofw-mips32-make-default
 #    - .core-defs
+
+#################################### MISC ####################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
+    - .core-defs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux 64-bit (ARM)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -116,6 +120,12 @@ libretro-build-linux-x64:
 libretro-build-linux-i686:
   extends:
     - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux 64-bit (ARM)
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1189,7 +1189,7 @@ static void dyn_ret_near(Bitu bytes) {
 		gen_call_function_raw((void*)&dynrec_pop_word);
 		gen_extend_word(false,FC_RETOP);
 	}
-	gen_mov_word_from_reg(FC_RETOP,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),true);
+	gen_mov_word_from_reg(FC_RETOP,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),decode.big_op);
 
 	if (bytes) gen_add_direct_word(&reg_esp,bytes,true);
 	dyn_return(BR_Normal);


### PR DESCRIPTION
The original parameter was `true` (32-bit store), but in 16-bit the destination is `&reg_ip`, which is only 16 bits. It worked accidentally in little-endian (the low bytes of the store fall onto reg_ip); in big-endian (Xenon/Broadway) `&reg_ip = &reg_ip+2`, so a 32-bit stw overwrites reg_ip with 0 (the MSBs of the extended value) and overflows into the next field of cpu_regs. Consequence: RET jumps to the upper half of the popped value (=0) instead of the lower half (= return real address). Symptom observed in PoP 1: RET after CALL E8 jumped to CS:0000 instead of the true return address.