### PR TITLE
Add option to override direct mouse coordinate range

### DIFF
--- a/core_options.h
+++ b/core_options.h
@@ -68,6 +68,7 @@ namespace DBP_Option
 		map_osd,
 		mouse_input,
 		mouse_wheel,
+        mouse_range_override,
 		mouse_speed_factor,
 		mouse_speed_factor_x,
 		actionwheel_inputs,
@@ -390,6 +391,22 @@ static retro_core_option_v2_definition option_defs[DBP_Option::_OPTIONS_TOTAL] =
 		},
 		"67/68"
 	},
+    {
+        "dosbox_pure_mouse_range_override",
+        "Mouse Range Override", NULL,
+        "Forces the DOS mouse coordinate range. Useful for games where direct touch input does not align with the visible cursor.", NULL,
+        // Such as Might and Magic 3/4/5
+		DBP_OptionCat::Input,
+        {
+            { "disabled", "disabled" },
+            { "320x200",  "320x200" },
+            { "640x200",  "640x200" },
+            { "640x400",  "640x400" },
+            { "640x480",  "640x480" },
+            { NULL, NULL },
+        },
+        "disabled"
+    },
 	{
 		"dosbox_pure_mouse_speed_factor",
 		"Mouse Sensitivity", NULL,

--- a/dosbox_pure_libretro.cpp
+++ b/dosbox_pure_libretro.cpp
@@ -122,6 +122,8 @@ static const char* DBP_YMLKeyCommands[KBD_LAST+3] =
 static std::vector<DBP_InputBind> dbp_input_binds;
 static Bit8u dbp_port_mode[DBP_MAX_PORTS], dbp_binds_changed, dbp_actionwheel_inputs;
 static Bit16s dbp_mouse_x, dbp_mouse_y;
+int dbp_mouse_max_x_override = 0;
+int dbp_mouse_max_y_override = 0;
 static int dbp_joy_analog_deadzone = (int)(0.15f * (float)DBP_JOY_ANALOG_RANGE);
 #define DBP_GET_JOY_ANALOG_VALUE(V) ((V >= -dbp_joy_analog_deadzone && V <= dbp_joy_analog_deadzone) ? 0.0f : \
 	((float)((V > dbp_joy_analog_deadzone) ? (V - dbp_joy_analog_deadzone) : (V + dbp_joy_analog_deadzone)) / (float)(DBP_JOY_ANALOG_RANGE - dbp_joy_analog_deadzone)))
@@ -2112,7 +2114,7 @@ void retro_get_system_info(struct retro_system_info *info) // #1
 {
 	memset(info, 0, sizeof(*info));
 	info->library_name     = "DOSBox-pure";
-	info->library_version  = DOSBOX_PURE_VERSION_STR;
+	info->library_version  = "0.9.9-finalpatch";
 	info->need_fullpath    = true;
 	info->block_extract    = true;
 	info->valid_extensions = "zip|dosz|exe|com|bat|iso|chd|cue|ins|img|ima|vhd|jrc|m3u|m3u8|conf|/";
@@ -2510,6 +2512,32 @@ static bool check_variables()
 
 	dbp_alphablend_base = (Bit8u)((atoi(DBP_Option::Get(DBP_Option::menu_transparency)) + 30) * 0xFF / 130);
 	dbp_joy_analog_deadzone = (int)((float)atoi(DBP_Option::Get(DBP_Option::joystick_analog_deadzone)) * 0.01f * (float)DBP_JOY_ANALOG_RANGE);
+
+    dbp_mouse_max_x_override = 0;
+    dbp_mouse_max_y_override = 0;
+
+    const char* mouse_range_override = DBP_Option::Get(DBP_Option::mouse_range_override);
+
+    if (!strcmp(mouse_range_override, "320x200"))
+    {
+        dbp_mouse_max_x_override = 319;
+        dbp_mouse_max_y_override = 199;
+    }
+    else if (!strcmp(mouse_range_override, "640x200"))
+    {
+        dbp_mouse_max_x_override = 639;
+        dbp_mouse_max_y_override = 199;
+    }
+    else if (!strcmp(mouse_range_override, "640x400"))
+    {
+        dbp_mouse_max_x_override = 639;
+        dbp_mouse_max_y_override = 399;
+    }
+    else if (!strcmp(mouse_range_override, "640x480"))
+    {
+        dbp_mouse_max_x_override = 639;
+        dbp_mouse_max_y_override = 479;
+    }
 
 	return visibility_changed;
 }

--- a/dosbox_pure_libretro.cpp
+++ b/dosbox_pure_libretro.cpp
@@ -2114,7 +2114,7 @@ void retro_get_system_info(struct retro_system_info *info) // #1
 {
 	memset(info, 0, sizeof(*info));
 	info->library_name     = "DOSBox-pure";
-	info->library_version  = "0.9.9-finalpatch";
+	info->library_version  = DOSBOX_PURE_VERSION_STR;
 	info->need_fullpath    = true;
 	info->block_extract    = true;
 	info->valid_extensions = "zip|dosz|exe|com|bat|iso|chd|cue|ins|img|ima|vhd|jrc|m3u|m3u8|conf|/";

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -133,6 +133,10 @@ static Bit8u mouse_vmware_cursor;
 static bool mouse_vmware_updated;
 bool mouse_vmware_usep60;
 
+extern int dbp_mouse_max_x_override;
+extern int dbp_mouse_max_y_override;
+
+
 bool Mouse_SetPS2State(bool use) {
 	if (use && (!ps2callbackinit)) {
 		useps2callback = false;
@@ -501,8 +505,13 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
 			mouse.y = y*(IS_EGAVGA_ARCH?(real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1):25)*8;
 		} else if ((mouse.max_x < 2048) || (mouse.max_y < 2048) || (mouse.max_x != mouse.max_y)) {
 			if ((mouse.max_x > 0) && (mouse.max_y > 0)) {
-				mouse.x = x*mouse.max_x;
-				mouse.y = y*mouse.max_y;
+                if (dbp_mouse_max_x_override > 0 && dbp_mouse_max_y_override > 0) {
+                    mouse.x = x*dbp_mouse_max_x_override;
+                    mouse.y = y*dbp_mouse_max_y_override;
+                } else {
+                    mouse.x = x*mouse.max_x;
+                    mouse.y = y*mouse.max_y;
+                }
 			} else {
 #ifdef C_DBP_LIBRETRO // DBP: use same speed for emulate true and false
 				mouse.x += dx;


### PR DESCRIPTION
This adds an option to override the direct mouse coordinate range for touch screen devices.

In Might and Magic 3/4/5, the game explicitly sets the mouse cursor range to x:2-309 and y:2-187 (using INT 33h feature 0x07 and 0x08).  I believe the game did this to keep the cursor sprite inside the frame buffer (so that it does not need to worry about clipping it).  But this also causes the direct mouse logic to use the 309/187 range to compute the cursor position and leads to the tapping position not aligning with cursor on screen.

This PR introduces a new option "mouse_range_override" that allows the user to override the mouse range so that the direct mouse coordinates are computed correctly using the actual game resolution (320x200), while keeping the game specified cursor range, and only use that for clampping.  We still get the coordinate range the game expects, but the scaling factor is fixed.

The new option defaults to "disabled" because most games either do not explicitly change the mouse range, or simply set it to the  screen resolution.

Edit:
Examples of games that require mouse range override to work correctly in direct mode:
- Might and Magic III Isles of Terra (override with 320x200)
- Might and Magic IV Clouds of Xeen (override with 320x200)
- Might and Magic V Darkside of Xeen (override with 320x200)
- KOEI Uncharted Water II (override with 640x480)
- KOEI Air Management II (override with 640x480)
- KOEI Teitoku no Ketsudan (Pacific Theater of Operations) (override with 640x480)