### PR TITLE
Build for WiiU, GameCube and Wii, and enable their stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,14 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
 
+  # Nintendo GameCube
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ngc-static.yml'
+
+  # Nintendo Wii
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wii-static.yml'
+
   # OpenDingux
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-mips32.yml'
@@ -193,17 +201,29 @@ libretro-build-tvos-arm64:
     - .core-defs
 
 #################################### CONSOLES #################################
-## Nintendo 3DS
-#libretro-build-ctr:
-#  extends:
-#    - .libretro-ctr-static-retroarch-master
-#    - .core-defs
+# Nintendo 3DS
+libretro-build-ctr:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs
 
-## Nintendo WiiU
-#libretro-build-wiiu:
-#  extends:
-#    - .libretro-wiiu-static-retroarch-master
-#    - .core-defs
+# Nintendo WiiU
+libretro-build-wiiu:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
+    - .core-defs
+
+# Nintendo GameCube
+libretro-build-ngc:
+  extends:
+    - .libretro-ngc-static-retroarch-master
+    - .core-defs
+
+# Nintendo Wii
+libretro-build-wii:
+  extends:
+    - .libretro-wii-static-retroarch-master
+    - .core-defs
 
 # Nintendo Switch
 libretro-build-libnx-aarch64:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -201,11 +201,13 @@ libretro-build-tvos-arm64:
     - .core-defs
 
 #################################### CONSOLES #################################
-# Nintendo 3DS
-libretro-build-ctr:
-  extends:
-    - .libretro-ctr-static-retroarch-master
-    - .core-defs
+## Nintendo 3DS
+## Still disabled: libctru declares a Thread type of its own, which collides
+## with this core's struct Thread, and that is a rename rather than a build fix.
+#libretro-build-ctr:
+#  extends:
+#    - .libretro-ctr-static-retroarch-master
+#    - .core-defs
 
 # Nintendo WiiU
 libretro-build-wiiu:

--- a/Makefile
+++ b/Makefile
@@ -110,13 +110,13 @@ else ifeq ($(platform),ngc)
   OUTNAME := dosbox_pure_libretro_ngc.a
   CXX     := $(DEVKITPPC)/bin/powerpc-eabi-g++
   AR      := $(DEVKITPPC)/bin/powerpc-eabi-ar
-  COMMONFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -D__POWERPC__ -D__ppc__ -DMSB_FIRST -DWORDS_BIGENDIAN=1
+  COMMONFLAGS += -I$(DEVKITPRO)/libogc/include -DGEKKO -DHW_DOL -mogc -mcpu=750 -meabi -mhard-float -D__POWERPC__ -D__ppc__ -DMSB_FIRST -DWORDS_BIGENDIAN=1
   STATIC_LINKING = 1
 else ifeq ($(platform),wii)
   OUTNAME := dosbox_pure_libretro_wii.a
   CXX     := $(DEVKITPPC)/bin/powerpc-eabi-g++
   AR      := $(DEVKITPPC)/bin/powerpc-eabi-ar
-  COMMONFLAGS += -DGEKKO -mrvl -mcpu=750 -meabi -mhard-float -fpermissive
+  COMMONFLAGS += -I$(DEVKITPRO)/libogc/include -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -fpermissive
   COMMONFLAGS += -U__INT32_TYPE__ -U__UINT32_TYPE__ -D__INT32_TYPE__=int -D__POWERPC__ -D__ppc__ -DMSB_FIRST -DWORDS_BIGENDIAN=1
   STATIC_LINKING = 1
 else ifeq ($(platform),wiiu)

--- a/include/dbp_threads.h
+++ b/include/dbp_threads.h
@@ -12,16 +12,11 @@ struct Semaphore { __inline Semaphore() : h(CreateSemaphoreA(0,0,1,0)) {} __inli
 struct SpinLock { __inline SpinLock() : f(0) {} __inline void Lock() { while (_InterlockedCompareExchange8(&f, 1, 0)) retro_sleep(0); } __inline void Unlock() { _ReadWriteBarrier(); f = false; } private:volatile char f;SpinLock(const SpinLock&);SpinLock& operator=(const SpinLock&);};
 #endif
 #else
-#if defined(WIIU)
-#include "../libretro-common/rthreads/wiiu_pthread.h"
-#elif defined(GEKKO)
-#include "../libretro-common/rthreads/gx_pthread.h"
-#elif defined(_3DS)
-#include "../libretro-common/rthreads/ctr_pthread.h"
-#else
+/* devkitPro ships real pthreads for WiiU, GameCube/Wii and the 3DS now, and
+ * libretro-common dropped its shims for all three - they collide with the
+ * toolchain's own declarations rather than standing in for them. */
 #include <pthread.h>
 #include <atomic>
-#endif
 #define THREAD_CC
 struct Thread { typedef void* RET_t; typedef RET_t (THREAD_CC *FUNC_t)(void*); static void StartDetached(FUNC_t f, void* p = NULL) { pthread_t h = 0; pthread_attr_t a; pthread_attr_init(&a); pthread_attr_setstacksize(&a, DBP_STACK_SIZE); pthread_create(&h, &a, f, p); pthread_attr_destroy(&a); pthread_detach(h); } };
 struct Mutex { __inline Mutex() { pthread_mutex_init(&h,0); } __inline ~Mutex() { pthread_mutex_destroy(&h); } __inline void Lock() { pthread_mutex_lock(&h); } __inline void Unlock() { pthread_mutex_unlock(&h); } private:pthread_mutex_t h;Mutex(const Mutex&);Mutex& operator=(const Mutex&);friend struct Conditional;};


### PR DESCRIPTION
Gets WiiU, GameCube and Wii building, and enables their stages. 3DS stays disabled — see the end.

The WiiU stage was commented out in 3b975c2, February 2021, as *"Disable failing console stages for now"*. It still failed, and so did GameCube and Wii, which never had stages at all. Three causes, all outside this core's own code:

**The pthread shims are gone from libretro-common.** `include/dbp_threads.h` pulls in `wiiu_pthread.h`, `gx_pthread.h` and `ctr_pthread.h` from the bundled copy, and upstream deleted all three — devkitPro provides real pthreads for these platforms now, so the shims collide with the toolchain rather than standing in for it:

```
wiiu  error: conflicting declaration 'typedef struct WiiUThread* pthread_t'
wii   error: conflicting declaration 'typedef lwp_t pthread_t'
```

So those three branches now fall through to `<pthread.h>` like every other platform.

**GameCube was being built as a Wii.** The `ngc` branch passed `-mrvl`, which makes the toolchain define `__wii__`, while `-DHW_DOL` makes libogc define `__gamecube__` — and `gctypes.h` errors out when both or neither are set:

```
/opt/devkitpro/libogc/include/gctypes.h:24:2: error: #error "Invalid platform selected"
```

It passes `-mogc` now, and the `wii` branch says `-DHW_RVL` explicitly rather than relying on the machine flag alone.

**Neither GEKKO branch could see libogc.** `features_cpu.inl` wants `ogc/lwp_watchdog.h`, which is in the toolchain but not on the include path, so both branches now add `-I$(DEVKITPRO)/libogc/include`.

**Built, not assumed.** Against `devkitpro/devkitppc`, from a tree with every object file deleted between runs:

```
platform=wiiu   ->  dosbox_pure_libretro_wiiu.a   5628390
platform=ngc    ->  dosbox_pure_libretro_ngc.a    5829598
platform=wii    ->  dosbox_pure_libretro_wii.a    5829598
```

What I have not done is link RetroArch around them or run any of it on hardware — that is the buildbot's half, and yours.

**3DS stays commented out.** With the shim removed it gets further and then stops somewhere this change cannot reach: libctru declares a `Thread` type of its own, which collides with this core's `struct Thread` in `dbp_threads.h`. That is a rename in the core, not a build fix, and it deserves its own change rather than being smuggled into this one.
